### PR TITLE
Diff-based Changelog

### DIFF
--- a/sawyer/github.py
+++ b/sawyer/github.py
@@ -1,12 +1,9 @@
-import re
 import requests
 import logging
 
 from .pull_request import PullRequest
 
 API_URI = 'https://api.github.com/repos/{owner}/{repo}'
-
-PR_MESSAGE_FORMAT = re.compile('^Merge pull request #(\d+) from (.*)')
 
 
 _log = logging.getLogger(__name__)
@@ -92,17 +89,3 @@ class DiffFetcher(GithubFetcher):
         ).json()
 
         return response['commits']
-
-    def merged_pr_numbers(self, base, head):
-        commits = self.fetch(base, head)
-
-        # Iterate through commits and identify merge commits
-
-        merged_pr_numbers = []
-
-        for commit in commits:
-            pr_message = PR_MESSAGE_FORMAT.match(commit['commit']['message'])
-            if pr_message:
-                merged_pr_numbers.append(int(pr_message.group(1)))
-
-        return merged_pr_numbers

--- a/sawyer/github.py
+++ b/sawyer/github.py
@@ -1,9 +1,12 @@
+import re
 import requests
 import logging
 
 from .pull_request import PullRequest
 
 API_URI = 'https://api.github.com/repos/{owner}/{repo}'
+
+PR_MESSAGE_FORMAT = re.compile('^Merge pull request #(\d+) from (.*)')
 
 
 _log = logging.getLogger(__name__)
@@ -64,7 +67,10 @@ class PullRequestFetcher(GithubFetcher):
         )
 
     def fetch(self, pr_numbers=None):
-        earliest_pr = sorted(pr_numbers)[0]
+        if pr_numbers:
+            earliest_pr = sorted(pr_numbers)[0]
+        else:
+            earliest_pr = 1
 
         raw_prs = self._fetch_recursive(1, stop_at=earliest_pr)
         pull_requests = []
@@ -86,3 +92,17 @@ class DiffFetcher(GithubFetcher):
         ).json()
 
         return response['commits']
+
+    def merged_pr_numbers(self, base, head):
+        commits = self.fetch(base, head)
+
+        # Iterate through commits and identify merge commits
+
+        merged_pr_numbers = []
+
+        for commit in commits:
+            pr_message = PR_MESSAGE_FORMAT.match(commit['commit']['message'])
+            if pr_message:
+                merged_pr_numbers.append(int(pr_message.group(1)))
+
+        return merged_pr_numbers

--- a/sawyer/github.py
+++ b/sawyer/github.py
@@ -2,6 +2,7 @@ import requests
 import logging
 
 from .pull_request import PullRequest
+
 API_URI = 'https://api.github.com/repos/{owner}/{repo}'
 
 
@@ -26,11 +27,11 @@ class GithubFetcher:
 class PullRequestFetcher(GithubFetcher):
     endpoint = '/pulls'
 
-    def _fetch_recursive(self, page, raw_prs=[]):
+    def _fetch_recursive(self, page, raw_prs=[], stop_at=None):
         params = {
             'state': 'all',
             'page': page,
-            'direction': 'asc'
+            'direction': 'desc'
         }
 
         response = requests.get(
@@ -43,23 +44,45 @@ class PullRequestFetcher(GithubFetcher):
         raw = response.json()
 
         # Until no content is returned, get more PRs
-        if raw:
-            for item in raw:
-                raw_prs.append(item)
-
-            _log.info('Got {} pull requests'.format(len(raw_prs)))
-            return self._fetch_recursive(page=page+1, raw_prs=raw_prs)
-        else:
+        if not raw:
             return raw_prs
 
-    def fetch(self):
-        raw_prs = self._fetch_recursive(1)
+        should_stop = False
+
+        for item in raw:
+            raw_prs.append(item)
+            if item['number'] <= stop_at:
+                should_stop = True
+
+        _log.info('Got {} pull requests'.format(len(raw_prs)))
+
+        if should_stop:
+            return raw_prs
+
+        return self._fetch_recursive(
+            page=page + 1, raw_prs=raw_prs, stop_at=stop_at
+        )
+
+    def fetch(self, pr_numbers=None):
+        earliest_pr = sorted(pr_numbers)[0]
+
+        raw_prs = self._fetch_recursive(1, stop_at=earliest_pr)
         pull_requests = []
         for pr in raw_prs:
+            if pr_numbers and pr['number'] not in pr_numbers:
+                continue
+
             pull_requests.append(PullRequest(pr))
 
         return pull_requests
 
 
-class TagFetcher(GithubFetcher):
-    endpoint = '/git/refs/tags'
+class DiffFetcher(GithubFetcher):
+    endpoint = '/compare/{base}...{head}'
+
+    def fetch(self, base, head):
+        response = requests.get(
+            self.uri.format(base=base, head=head), auth=self.auth
+        ).json()
+
+        return response['commits']

--- a/sawyer/templates/default.md
+++ b/sawyer/templates/default.md
@@ -5,7 +5,7 @@
 **Added**:
 
 {% for pr in pull_requests -%}
-- {{ pr.raw.title }} 
+- {{ pr.raw.title }}
   ([@{{ pr.user }}](https://github.com/{{ pr.user }}/)
   in [\#{{pr.number}}](https://github.com/{{ owner }}/{{ repo }}/pull/{{ pr.number }}/))
 {% endfor %}

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,6 @@ setup(
         'markdown',
         'Jinja2',
         'requests',
-        'python-dateutil',
-        'pytz',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
There are a few things in here:
- Switching the current strategy of PRs merged since last release tag to regexing for merge commits in a diff between the previous tag and `head`. Most notably this protects against pull requests that are merged while a release branch is open being omitted from the changelog
- Providing the `PullRequestFetcher` with more context so we can do less overfetching against the github API (specifically for repos with large numbers of pull requests)
- Removing trailing whitespace from the changelog template
